### PR TITLE
Implement XMLDOC support

### DIFF
--- a/src/CodeGenHelpers/ClassBuilder.cs
+++ b/src/CodeGenHelpers/ClassBuilder.cs
@@ -26,6 +26,8 @@ namespace CodeGenHelpers
             _isPartial = partial;
         }
 
+        public DocumentationComment XmlDoc { get; } = new DocumentationComment();
+
         public string Name { get; }
 
         public string FullyQualifiedName => $"{Builder.Namespace}.{Name}";
@@ -49,6 +51,19 @@ namespace CodeGenHelpers
         public bool IsStatic { get; private set; }
 
         public bool IsSealed { get; private set; }
+
+        public ClassBuilder WithSummary(string summary)
+        {
+            XmlDoc.Summary = summary;
+            return this;
+        }
+
+        public ClassBuilder WithInheritDoc(bool inherit = true, string from = null)
+        {
+            XmlDoc.InheritDoc = inherit;
+            XmlDoc.InheritFrom = from;
+            return this;
+        }
 
         public ClassBuilder Sealed()
         {
@@ -228,6 +243,8 @@ namespace CodeGenHelpers
 
         void IBuilder.Write(ref CodeWriter writer)
         {
+            XmlDoc.Write(ref writer);
+
             WriteClassAttributes(_classAttributes, ref writer);
 
             var staticDeclaration = IsStatic ? "static " : string.Empty;

--- a/src/CodeGenHelpers/ClassBuilder.cs
+++ b/src/CodeGenHelpers/ClassBuilder.cs
@@ -18,6 +18,7 @@ namespace CodeGenHelpers
         private readonly Queue<ClassBuilder> _nestedClass = new Queue<ClassBuilder>();
         private readonly List<string> _constraints = new List<string>();
         private readonly bool _isPartial;
+        private readonly DocumentationComment _xmlDoc = new DocumentationComment();
 
         internal ClassBuilder(string className, CodeBuilder codeBuilder, bool partial = true)
         {
@@ -25,8 +26,6 @@ namespace CodeGenHelpers
             Builder = codeBuilder;
             _isPartial = partial;
         }
-
-        public DocumentationComment XmlDoc { get; } = new DocumentationComment();
 
         public string Name { get; }
 
@@ -54,14 +53,14 @@ namespace CodeGenHelpers
 
         public ClassBuilder WithSummary(string summary)
         {
-            XmlDoc.Summary = summary;
+            _xmlDoc.Summary = summary;
             return this;
         }
 
         public ClassBuilder WithInheritDoc(bool inherit = true, string from = null)
         {
-            XmlDoc.InheritDoc = inherit;
-            XmlDoc.InheritFrom = from;
+            _xmlDoc.InheritDoc = inherit;
+            _xmlDoc.InheritFrom = from;
             return this;
         }
 
@@ -243,7 +242,7 @@ namespace CodeGenHelpers
 
         void IBuilder.Write(ref CodeWriter writer)
         {
-            XmlDoc.Write(ref writer);
+            _xmlDoc.Write(ref writer);
 
             WriteClassAttributes(_classAttributes, ref writer);
 

--- a/src/CodeGenHelpers/ClassBuilder.cs
+++ b/src/CodeGenHelpers/ClassBuilder.cs
@@ -54,12 +54,20 @@ namespace CodeGenHelpers
         public ClassBuilder WithSummary(string summary)
         {
             _xmlDoc.Summary = summary;
+            _xmlDoc.InheritDoc = false;
             return this;
         }
 
-        public ClassBuilder WithInheritDoc(bool inherit = true, string from = null)
+        public ClassBuilder WithInheritDoc(bool inherit = true)
         {
             _xmlDoc.InheritDoc = inherit;
+            _xmlDoc.InheritFrom = null;
+            return this;
+        }
+
+        public ClassBuilder WithInheritDoc(string from)
+        {
+            _xmlDoc.InheritDoc = true;
             _xmlDoc.InheritFrom = from;
             return this;
         }

--- a/src/CodeGenHelpers/CodeBuilder.cs
+++ b/src/CodeGenHelpers/CodeBuilder.cs
@@ -10,7 +10,7 @@ namespace CodeGenHelpers
     {
         private readonly List<string> _namespaceImports = new List<string>();
         private readonly List<string> _assemblyAttributes = new List<string>();
-        private readonly Queue<IBuilder> _classes = new Queue<IBuilder>();
+        private readonly List<IBuilder> _classes = new List<IBuilder>();
 
         private CodeBuilder(string clrNamespace, IndentStyle indentStyle = IndentStyle.Spaces)
         {
@@ -68,7 +68,7 @@ namespace CodeGenHelpers
         public ClassBuilder AddClass(string name)
         {
             var builder = new ClassBuilder(name, this);
-            _classes.Enqueue(builder);
+            _classes.Add(builder);
             return builder;
         }
 
@@ -80,8 +80,15 @@ namespace CodeGenHelpers
         public EnumBuilder AddEnum(string name)
         {
             var builder = new EnumBuilder(name, this);
-            _classes.Enqueue(builder);
+            _classes.Add(builder);
             return builder;
+        }
+
+        public void Clear()
+        {
+            _namespaceImports.Clear();
+            _assemblyAttributes.Clear();
+            _classes.Clear();
         }
 
         private CodeWriter BuildInternal()
@@ -103,12 +110,12 @@ namespace CodeGenHelpers
             WriteAssemblyAttributes(_assemblyAttributes, ref writer);
             using (writer.Block($"namespace {Namespace}"))
             {
-                while (_classes.Any())
+                for (int i = 0; i < _classes.Count; i++)
                 {
-                    var output = _classes.Dequeue();
-                    output.Write(ref writer);
+                    var current = _classes[i];
+                    current.Write(ref writer);
 
-                    if (_classes.Any())
+                    if (i + 1 < _classes.Count)
                         writer.NewLine();
                 }
             }

--- a/src/CodeGenHelpers/CodeGenHelpers.projitems
+++ b/src/CodeGenHelpers/CodeGenHelpers.projitems
@@ -26,5 +26,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)LogicalConditionBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MethodBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PropertyBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DocumentationComment.cs" />
   </ItemGroup>
 </Project>

--- a/src/CodeGenHelpers/ConstructorBuilder.cs
+++ b/src/CodeGenHelpers/ConstructorBuilder.cs
@@ -21,11 +21,35 @@ namespace CodeGenHelpers
             Class = classBuilder;
         }
 
+        public DocumentationComment XmlDoc { get; } = new DocumentationComment();
+
         public Accessibility? AccessModifier { get; }
 
         public ClassBuilder Class { get; }
 
         internal int Parameters => _parameters.Count;
+
+        public ConstructorBuilder WithSummary(string summary)
+        {
+            XmlDoc.Summary = summary;
+            return this;
+        }
+
+        public ConstructorBuilder WithInheritDoc(bool inherit = true, string from = null)
+        {
+            XmlDoc.InheritDoc = inherit;
+            XmlDoc.InheritFrom = from;
+            return this;
+        }
+
+        public ConstructorBuilder WithParameterDoc(string paramName, string documentation)
+        {
+            // The reason why I don't check if the parameter exists,
+            // is that maybe the user wants to add the parameter later themselves
+            // and an extra xmldoc won't really cause issue.
+            XmlDoc.ParameterDoc[paramName] = documentation;
+            return this;
+        }
 
         public ConstructorBuilder AddParameter(string typeName, string parameterName = null)
         {
@@ -181,6 +205,8 @@ namespace CodeGenHelpers
 
         void IBuilder.Write(ref CodeWriter writer)
         {
+            XmlDoc.Write(ref writer);
+
             foreach (var attribute in _attributes)
                 writer.AppendLine($"[{attribute}]");
 

--- a/src/CodeGenHelpers/ConstructorBuilder.cs
+++ b/src/CodeGenHelpers/ConstructorBuilder.cs
@@ -30,12 +30,20 @@ namespace CodeGenHelpers
         public ConstructorBuilder WithSummary(string summary)
         {
             _xmlDoc.Summary = summary;
+            _xmlDoc.InheritDoc = false;
             return this;
         }
 
-        public ConstructorBuilder WithInheritDoc(bool inherit = true, string from = null)
+        public ConstructorBuilder WithInheritDoc(bool inherit = true)
         {
             _xmlDoc.InheritDoc = inherit;
+            _xmlDoc.InheritFrom = null;
+            return this;
+        }
+
+        public ConstructorBuilder WithInheritDoc(string from)
+        {
+            _xmlDoc.InheritDoc = true;
             _xmlDoc.InheritFrom = from;
             return this;
         }

--- a/src/CodeGenHelpers/ConstructorBuilder.cs
+++ b/src/CodeGenHelpers/ConstructorBuilder.cs
@@ -9,7 +9,7 @@ namespace CodeGenHelpers
     {
         private readonly Dictionary<string, string> _parameters = new Dictionary<string, string>();
         private readonly List<string> _attributes = new List<string>();
-        private readonly DocumentationComment _xmlDoc = new DocumentationComment();
+        private readonly DocumentationComment _xmlDoc = new DocumentationComment(true);
 
         private Action<ICodeWriter> _methodBodyWriter;
 

--- a/src/CodeGenHelpers/ConstructorBuilder.cs
+++ b/src/CodeGenHelpers/ConstructorBuilder.cs
@@ -8,8 +8,8 @@ namespace CodeGenHelpers
     public sealed class ConstructorBuilder : IBuilder
     {
         private readonly Dictionary<string, string> _parameters = new Dictionary<string, string>();
-
         private readonly List<string> _attributes = new List<string>();
+        private readonly DocumentationComment _xmlDoc = new DocumentationComment();
 
         private Action<ICodeWriter> _methodBodyWriter;
 
@@ -21,8 +21,6 @@ namespace CodeGenHelpers
             Class = classBuilder;
         }
 
-        public DocumentationComment XmlDoc { get; } = new DocumentationComment();
-
         public Accessibility? AccessModifier { get; }
 
         public ClassBuilder Class { get; }
@@ -31,23 +29,20 @@ namespace CodeGenHelpers
 
         public ConstructorBuilder WithSummary(string summary)
         {
-            XmlDoc.Summary = summary;
+            _xmlDoc.Summary = summary;
             return this;
         }
 
         public ConstructorBuilder WithInheritDoc(bool inherit = true, string from = null)
         {
-            XmlDoc.InheritDoc = inherit;
-            XmlDoc.InheritFrom = from;
+            _xmlDoc.InheritDoc = inherit;
+            _xmlDoc.InheritFrom = from;
             return this;
         }
 
         public ConstructorBuilder WithParameterDoc(string paramName, string documentation)
         {
-            // The reason why I don't check if the parameter exists,
-            // is that maybe the user wants to add the parameter later themselves
-            // and an extra xmldoc won't really cause issue.
-            XmlDoc.ParameterDoc[paramName] = documentation;
+            _xmlDoc.ParameterDoc[paramName] = documentation;
             return this;
         }
 
@@ -205,7 +200,8 @@ namespace CodeGenHelpers
 
         void IBuilder.Write(ref CodeWriter writer)
         {
-            XmlDoc.Write(ref writer);
+            _xmlDoc.RemoveUnusedParameters(_parameters);
+            _xmlDoc.Write(ref writer);
 
             foreach (var attribute in _attributes)
                 writer.AppendLine($"[{attribute}]");

--- a/src/CodeGenHelpers/DocumentationComment.cs
+++ b/src/CodeGenHelpers/DocumentationComment.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace CodeGenHelpers
+{
+    public class DocumentationComment
+    {
+        public string? Summary { get; set; }
+
+        public Dictionary<string, string> ParameterDoc { get; } = new Dictionary<string, string>();
+
+        public bool InheritDoc { get; set; }
+
+        public string? InheritFrom { get; set; }
+
+        public void Write(ref CodeWriter writer)
+        {
+            if (InheritDoc)
+            {
+                writer.AppendLine($"/// <inheritdoc {(InheritFrom is null ? "" : $"cref=\"{InheritFrom}\"")}/>");
+                return;
+            }
+
+            if (Summary is {})
+            {
+                writer.AppendLine("/// <summary>");
+
+                foreach (string line in Summary.Split('\n'))
+                    writer.AppendLine($"/// {line}");
+
+                writer.AppendLine("/// </summary>");
+            }
+
+            foreach (var param in ParameterDoc)
+                writer.AppendLine($"/// <param name=\"{param.Key}\">{param.Value}</param>");
+        }
+    }
+}

--- a/src/CodeGenHelpers/DocumentationComment.cs
+++ b/src/CodeGenHelpers/DocumentationComment.cs
@@ -12,7 +12,7 @@ namespace CodeGenHelpers
 
         public string? InheritFrom { get; set; }
 
-        public void Write(ref CodeWriter writer)
+        internal void Write(ref CodeWriter writer)
         {
             if (InheritDoc)
             {

--- a/src/CodeGenHelpers/DocumentationComment.cs
+++ b/src/CodeGenHelpers/DocumentationComment.cs
@@ -1,22 +1,24 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
 
 namespace CodeGenHelpers
 {
-    public class DocumentationComment
+    internal class DocumentationComment
     {
-        public string? Summary { get; set; }
+        internal string? Summary { get; set; }
 
-        public Dictionary<string, string> ParameterDoc { get; } = new Dictionary<string, string>();
+        internal Dictionary<string, string> ParameterDoc { get; } = new Dictionary<string, string>();
 
-        public bool InheritDoc { get; set; }
+        internal bool InheritDoc { get; set; }
 
-        public string? InheritFrom { get; set; }
+        internal string? InheritFrom { get; set; }
 
         internal void Write(ref CodeWriter writer)
         {
             if (InheritDoc)
             {
-                writer.AppendLine($"/// <inheritdoc {(InheritFrom is null ? "" : $"cref=\"{InheritFrom}\"")}/>");
+                writer.AppendLine($"/// <inheritdoc {(InheritFrom is null ? string.Empty : $"cref=\"{InheritFrom}\"")}/>");
                 return;
             }
 
@@ -24,7 +26,8 @@ namespace CodeGenHelpers
             {
                 writer.AppendLine("/// <summary>");
 
-                foreach (string line in Summary.Split('\n'))
+                string[] lines = Summary.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+                foreach (string line in lines)
                     writer.AppendLine($"/// {line}");
 
                 writer.AppendLine("/// </summary>");
@@ -32,6 +35,13 @@ namespace CodeGenHelpers
 
             foreach (var param in ParameterDoc)
                 writer.AppendLine($"/// <param name=\"{param.Key}\">{param.Value}</param>");
+        }
+
+        internal void RemoveUnusedParameters(Dictionary<string, string> parameters)
+        {
+            var unusedParameters = ParameterDoc.Where(p => !parameters.ContainsKey(p.Key)).ToArray();
+            foreach ((var name, var _) in unusedParameters)
+                ParameterDoc.Remove(name);
         }
     }
 }

--- a/src/CodeGenHelpers/DocumentationComment.cs
+++ b/src/CodeGenHelpers/DocumentationComment.cs
@@ -6,9 +6,16 @@ namespace CodeGenHelpers
 {
     internal class DocumentationComment
     {
+        internal DocumentationComment(bool supportsParameterDoc = false)
+        {
+            ParameterDoc = supportsParameterDoc
+                ? new Dictionary<string, string>()
+                : null;
+        }
+
         internal string? Summary { get; set; }
 
-        internal Dictionary<string, string> ParameterDoc { get; } = new Dictionary<string, string>();
+        internal Dictionary<string, string>? ParameterDoc { get; }
 
         internal bool InheritDoc { get; set; }
 
@@ -33,8 +40,11 @@ namespace CodeGenHelpers
                 writer.AppendLine("/// </summary>");
             }
 
-            foreach (var param in ParameterDoc)
-                writer.AppendLine($"/// <param name=\"{param.Key}\">{param.Value}</param>");
+            if (ParameterDoc is {})
+            {
+                foreach (var param in ParameterDoc)
+                    writer.AppendLine($"/// <param name=\"{param.Key}\">{param.Value}</param>");
+            }
         }
 
         internal void RemoveUnusedParameters(Dictionary<string, string> parameters)

--- a/src/CodeGenHelpers/EnumBuilder.cs
+++ b/src/CodeGenHelpers/EnumBuilder.cs
@@ -25,12 +25,20 @@ namespace CodeGenHelpers
         public EnumBuilder WithSummary(string summary)
         {
             _xmlDoc.Summary = summary;
+            _xmlDoc.InheritDoc = false;
             return this;
         }
 
-        public EnumBuilder WithInheritDoc(bool inherit = true, string from = null)
+        public EnumBuilder WithInheritDoc(bool inherit = true)
         {
             _xmlDoc.InheritDoc = inherit;
+            _xmlDoc.InheritFrom = null;
+            return this;
+        }
+
+        public EnumBuilder WithInheritDoc(string from)
+        {
+            _xmlDoc.InheritDoc = true;
             _xmlDoc.InheritFrom = from;
             return this;
         }

--- a/src/CodeGenHelpers/EnumBuilder.cs
+++ b/src/CodeGenHelpers/EnumBuilder.cs
@@ -17,9 +17,24 @@ namespace CodeGenHelpers
 
         public CodeBuilder Builder { get; }
 
+        public DocumentationComment XmlDoc { get; } = new DocumentationComment();
+
         public string Name { get; }
 
         public Accessibility? AccessModifier { get; private set; }
+
+        public EnumBuilder WithSummary(string summary)
+        {
+            XmlDoc.Summary = summary;
+            return this;
+        }
+
+        public EnumBuilder WithInheritDoc(bool inherit = true, string from = null)
+        {
+            XmlDoc.InheritDoc = inherit;
+            XmlDoc.InheritFrom = from;
+            return this;
+        }
 
         public EnumValueBuilder AddValue(string name, int? numericValue = null)
         {
@@ -67,6 +82,8 @@ namespace CodeGenHelpers
 
         void IBuilder.Write(ref CodeWriter writer)
         {
+            XmlDoc.Write(ref writer);
+
             var queue = new Queue<IBuilder>();
             _values.OrderBy(x => x.Value)
                 .ThenBy(x => x.Name)

--- a/src/CodeGenHelpers/EnumBuilder.cs
+++ b/src/CodeGenHelpers/EnumBuilder.cs
@@ -8,6 +8,7 @@ namespace CodeGenHelpers
     {
         private readonly List<string> _attributes = new List<string>();
         private readonly List<EnumValueBuilder> _values = new List<EnumValueBuilder>();
+        private readonly DocumentationComment _xmlDoc = new DocumentationComment();
 
         internal EnumBuilder(string name, CodeBuilder builder)
         {
@@ -17,22 +18,20 @@ namespace CodeGenHelpers
 
         public CodeBuilder Builder { get; }
 
-        public DocumentationComment XmlDoc { get; } = new DocumentationComment();
-
         public string Name { get; }
 
         public Accessibility? AccessModifier { get; private set; }
 
         public EnumBuilder WithSummary(string summary)
         {
-            XmlDoc.Summary = summary;
+            _xmlDoc.Summary = summary;
             return this;
         }
 
         public EnumBuilder WithInheritDoc(bool inherit = true, string from = null)
         {
-            XmlDoc.InheritDoc = inherit;
-            XmlDoc.InheritFrom = from;
+            _xmlDoc.InheritDoc = inherit;
+            _xmlDoc.InheritFrom = from;
             return this;
         }
 
@@ -82,7 +81,7 @@ namespace CodeGenHelpers
 
         void IBuilder.Write(ref CodeWriter writer)
         {
-            XmlDoc.Write(ref writer);
+            _xmlDoc.Write(ref writer);
 
             var queue = new Queue<IBuilder>();
             _values.OrderBy(x => x.Value)

--- a/src/CodeGenHelpers/EnumValueBuilder.cs
+++ b/src/CodeGenHelpers/EnumValueBuilder.cs
@@ -24,12 +24,20 @@ namespace CodeGenHelpers
         public EnumValueBuilder WithSummary(string summary)
         {
             _xmlDoc.Summary = summary;
+            _xmlDoc.InheritDoc = false;
             return this;
         }
 
-        public EnumValueBuilder WithInheritDoc(bool inherit = true, string from = null)
+        public EnumValueBuilder WithInheritDoc(bool inherit = true)
         {
             _xmlDoc.InheritDoc = inherit;
+            _xmlDoc.InheritFrom = null;
+            return this;
+        }
+
+        public EnumValueBuilder WithInheritDoc(string from)
+        {
+            _xmlDoc.InheritDoc = true;
             _xmlDoc.InheritFrom = from;
             return this;
         }

--- a/src/CodeGenHelpers/EnumValueBuilder.cs
+++ b/src/CodeGenHelpers/EnumValueBuilder.cs
@@ -14,11 +14,26 @@ namespace CodeGenHelpers
             Enum = builder;
         }
 
+        public DocumentationComment XmlDoc { get; } = new DocumentationComment();
+
         public string Name { get; }
 
         public int? Value { get; private set; }
 
         public EnumBuilder Enum { get; }
+
+        public EnumValueBuilder WithSummary(string summary)
+        {
+            XmlDoc.Summary = summary;
+            return this;
+        }
+
+        public EnumValueBuilder WithInheritDoc(bool inherit = true, string from = null)
+        {
+            XmlDoc.InheritDoc = inherit;
+            XmlDoc.InheritFrom = from;
+            return this;
+        }
 
         public EnumValueBuilder AddValue(string value, int? numericValue = null)
         {
@@ -36,6 +51,8 @@ namespace CodeGenHelpers
 
         void IBuilder.Write(ref CodeWriter writer)
         {
+            XmlDoc.Write(ref writer);
+
             foreach (var attr in _attributes.OrderBy(x => x))
             {
                 writer.AppendLine($"[{attr}]");

--- a/src/CodeGenHelpers/EnumValueBuilder.cs
+++ b/src/CodeGenHelpers/EnumValueBuilder.cs
@@ -6,6 +6,7 @@ namespace CodeGenHelpers
     public class EnumValueBuilder : IBuilder
     {
         private readonly List<string> _attributes = new List<string>();
+        private readonly DocumentationComment _xmlDoc = new DocumentationComment();
 
         internal EnumValueBuilder(string name, EnumBuilder builder, int? value)
         {
@@ -13,8 +14,6 @@ namespace CodeGenHelpers
             Value = value;
             Enum = builder;
         }
-
-        public DocumentationComment XmlDoc { get; } = new DocumentationComment();
 
         public string Name { get; }
 
@@ -24,14 +23,14 @@ namespace CodeGenHelpers
 
         public EnumValueBuilder WithSummary(string summary)
         {
-            XmlDoc.Summary = summary;
+            _xmlDoc.Summary = summary;
             return this;
         }
 
         public EnumValueBuilder WithInheritDoc(bool inherit = true, string from = null)
         {
-            XmlDoc.InheritDoc = inherit;
-            XmlDoc.InheritFrom = from;
+            _xmlDoc.InheritDoc = inherit;
+            _xmlDoc.InheritFrom = from;
             return this;
         }
 
@@ -51,7 +50,7 @@ namespace CodeGenHelpers
 
         void IBuilder.Write(ref CodeWriter writer)
         {
-            XmlDoc.Write(ref writer);
+            _xmlDoc.Write(ref writer);
 
             foreach (var attr in _attributes.OrderBy(x => x))
             {

--- a/src/CodeGenHelpers/MethodBuilder.cs
+++ b/src/CodeGenHelpers/MethodBuilder.cs
@@ -22,6 +22,8 @@ namespace CodeGenHelpers
             Class = builder;
         }
 
+        public DocumentationComment XmlDoc { get; } = new DocumentationComment();
+
         public string Name { get; }
 
         public string ReturnType { get; private set; }
@@ -46,6 +48,28 @@ namespace CodeGenHelpers
         public Accessibility? AccessModifier { get; private set; }
 
         public bool IsStatic { get; private set; }
+
+        public MethodBuilder WithSummary(string summary)
+        {
+            XmlDoc.Summary = summary;
+            return this;
+        }
+
+        public MethodBuilder WithInheritDoc(bool inherit = true, string from = null)
+        {
+            XmlDoc.InheritDoc = inherit;
+            XmlDoc.InheritFrom = from;
+            return this;
+        }
+
+        public MethodBuilder WithParameterDoc(string paramName, string documentation)
+        {
+            // The reason why I don't check if the parameter exists,
+            // is that maybe the user wants to add the parameter later themselves
+            // and an extra xmldoc won't really cause issue.
+            XmlDoc.ParameterDoc[paramName] = documentation;
+            return this;
+        }
 
         public MethodBuilder AddConstraint(string constraint)
         {
@@ -181,6 +205,8 @@ namespace CodeGenHelpers
 
             var parameters = string.Join(", ", _parameters.Select(x => $"{x.Value} {x.Key}"));
             output = $"{AccessModifier.Code()} {output} {Name}({parameters})";
+
+            XmlDoc.Write(ref writer);
 
             foreach (var attribute in _attributes)
                 writer.AppendLine($"[{attribute}]");

--- a/src/CodeGenHelpers/MethodBuilder.cs
+++ b/src/CodeGenHelpers/MethodBuilder.cs
@@ -51,12 +51,20 @@ namespace CodeGenHelpers
         public MethodBuilder WithSummary(string summary)
         {
             _xmlDoc.Summary = summary;
+            _xmlDoc.InheritDoc = false;
             return this;
         }
 
-        public MethodBuilder WithInheritDoc(bool inherit = true, string from = null)
+        public MethodBuilder WithInheritDoc(bool inherit = true)
         {
             _xmlDoc.InheritDoc = inherit;
+            _xmlDoc.InheritFrom = null;
+            return this;
+        }
+
+        public MethodBuilder WithInheritDoc(string from)
+        {
+            _xmlDoc.InheritDoc = true;
             _xmlDoc.InheritFrom = from;
             return this;
         }

--- a/src/CodeGenHelpers/MethodBuilder.cs
+++ b/src/CodeGenHelpers/MethodBuilder.cs
@@ -10,7 +10,7 @@ namespace CodeGenHelpers
         private readonly List<string> _attributes = new List<string>();
         private readonly List<string> _constraints = new List<string>();
         private readonly List<KeyValuePair<string, string>> _parameters = new List<KeyValuePair<string, string>>();
-        private readonly DocumentationComment _xmlDoc = new DocumentationComment();
+        private readonly DocumentationComment _xmlDoc = new DocumentationComment(true);
         private bool _override;
         private bool _virtual;
 

--- a/src/CodeGenHelpers/PropertyBuilder.cs
+++ b/src/CodeGenHelpers/PropertyBuilder.cs
@@ -25,6 +25,7 @@ namespace CodeGenHelpers
         private bool _getOnly;
         private Accessibility? _setterAccessibility;
         private readonly List<string> _attributes = new List<string>();
+        private readonly DocumentationComment _xmlDoc = new DocumentationComment();
 
         internal PropertyBuilder(string name, Accessibility? accessModifier, ClassBuilder builder)
         {
@@ -32,8 +33,6 @@ namespace CodeGenHelpers
             AccessModifier = accessModifier;
             Class = builder;
         }
-
-        public DocumentationComment XmlDoc { get; } = new DocumentationComment();
 
         public string Name { get; }
 
@@ -47,14 +46,14 @@ namespace CodeGenHelpers
 
         public PropertyBuilder WithSummary(string summary)
         {
-            XmlDoc.Summary = summary;
+            _xmlDoc.Summary = summary;
             return this;
         }
 
         public PropertyBuilder WithInheritDoc(bool inherit = true, string from = null)
         {
-            XmlDoc.InheritDoc = inherit;
-            XmlDoc.InheritFrom = from;
+            _xmlDoc.InheritDoc = inherit;
+            _xmlDoc.InheritFrom = from;
             return this;
         }
 
@@ -191,7 +190,7 @@ namespace CodeGenHelpers
 
         void IBuilder.Write(ref CodeWriter writer)
         {
-            XmlDoc.Write(ref writer);
+            _xmlDoc.Write(ref writer);
 
             foreach (var attribute in _attributes)
                 writer.AppendLine($"[{attribute}]");

--- a/src/CodeGenHelpers/PropertyBuilder.cs
+++ b/src/CodeGenHelpers/PropertyBuilder.cs
@@ -33,6 +33,8 @@ namespace CodeGenHelpers
             Class = builder;
         }
 
+        public DocumentationComment XmlDoc { get; } = new DocumentationComment();
+
         public string Name { get; }
 
         public string Type { get; private set; }
@@ -42,6 +44,19 @@ namespace CodeGenHelpers
         public Accessibility? AccessModifier { get; private set; }
 
         public bool IsStatic { get; private set; }
+
+        public PropertyBuilder WithSummary(string summary)
+        {
+            XmlDoc.Summary = summary;
+            return this;
+        }
+
+        public PropertyBuilder WithInheritDoc(bool inherit = true, string from = null)
+        {
+            XmlDoc.InheritDoc = inherit;
+            XmlDoc.InheritFrom = from;
+            return this;
+        }
 
         public PropertyBuilder AddNamespaceImport(string importedNamespace)
         {
@@ -176,6 +191,8 @@ namespace CodeGenHelpers
 
         void IBuilder.Write(ref CodeWriter writer)
         {
+            XmlDoc.Write(ref writer);
+
             foreach (var attribute in _attributes)
                 writer.AppendLine($"[{attribute}]");
 

--- a/src/CodeGenHelpers/PropertyBuilder.cs
+++ b/src/CodeGenHelpers/PropertyBuilder.cs
@@ -47,12 +47,20 @@ namespace CodeGenHelpers
         public PropertyBuilder WithSummary(string summary)
         {
             _xmlDoc.Summary = summary;
+            _xmlDoc.InheritDoc = false;
             return this;
         }
 
-        public PropertyBuilder WithInheritDoc(bool inherit = true, string from = null)
+        public PropertyBuilder WithInheritDoc(bool inherit = true)
         {
             _xmlDoc.InheritDoc = inherit;
+            _xmlDoc.InheritFrom = null;
+            return this;
+        }
+
+        public PropertyBuilder WithInheritDoc(string from)
+        {
+            _xmlDoc.InheritDoc = true;
             _xmlDoc.InheritFrom = from;
             return this;
         }


### PR DESCRIPTION
Also, I changed the way the `Build()` method works, because it mutates internal state, and while I was testing/debugging this, it confused the hell out of me because I kept getting empty output (the debugger called `ToString()` first, which called `Build()`, which mutated the internal state, so when my code called `Build()` later, it returned empty output). So instead I added a `Clear` method if the user wants to reuse the same instance but wants to clear it.