### PR TITLE
Fix warnings about NRT not being enabled

### DIFF
--- a/src/CodeGenHelpers/DocumentationComment.cs
+++ b/src/CodeGenHelpers/DocumentationComment.cs
@@ -13,13 +13,13 @@ namespace CodeGenHelpers
                 : null;
         }
 
-        internal string? Summary { get; set; }
+        internal string Summary { get; set; }
 
-        internal Dictionary<string, string>? ParameterDoc { get; }
+        internal Dictionary<string, string> ParameterDoc { get; }
 
         internal bool InheritDoc { get; set; }
 
-        internal string? InheritFrom { get; set; }
+        internal string InheritFrom { get; set; }
 
         internal void Write(ref CodeWriter writer)
         {


### PR DESCRIPTION
By mistake, I accidentally tried to use NRT, but it is not enabled for my project, and as I looked over the source code of CodeGenHelpers, the default is not using them, so I removed the 3 `?`s that were causing the warnings.