### PR TITLE
Compile ISymbolExtensions all the time, not only when `TEST` is set

### DIFF
--- a/src/CodeGenHelpers/Extensions/ISymbolExtensions.cs
+++ b/src/CodeGenHelpers/Extensions/ISymbolExtensions.cs
@@ -1,5 +1,4 @@
-﻿#if TEST
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -117,4 +116,3 @@ namespace CodeGenHelpers
         }
     }
 }
-#endif


### PR DESCRIPTION
Resolves #16 