### PR TITLE
allow Pragma warning disable

### DIFF
--- a/src/CodeGenHelpers/BuilderBase.cs
+++ b/src/CodeGenHelpers/BuilderBase.cs
@@ -1,10 +1,28 @@
-﻿namespace CodeGenHelpers
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace CodeGenHelpers
 {
     public abstract class BuilderBase : IBuilder
     {
+        protected readonly List<string> _pragmaWarnings = new List<string>();
+
         internal abstract void Write(ref CodeWriter writer);
 
-        void IBuilder.Write(ref CodeWriter writer) =>
+        void IBuilder.Write(ref CodeWriter writer)
+        {
+            var warnings = string.Join(", ", _pragmaWarnings.Distinct());
+            if(_pragmaWarnings.Any())
+            {
+                writer.AppendUnindentedLine($"#pragma warning disable {warnings}");
+            }
+
             Write(ref writer);
+
+            if (_pragmaWarnings.Any())
+            {
+                writer.AppendUnindentedLine($"#pragma warning restore {warnings}");
+            }
+        }
     }
 }

--- a/src/CodeGenHelpers/BuilderBase{T}.cs
+++ b/src/CodeGenHelpers/BuilderBase{T}.cs
@@ -9,5 +9,10 @@ namespace CodeGenHelpers
         public abstract T AddNamespaceImport(ISymbol symbol);
         public abstract T AddNamespaceImport(INamespaceSymbol symbol);
         public abstract T AddAssemblyAttribute(string attribute);
+        public T DisableWarning(string buildCode)
+        {
+            _pragmaWarnings.Add(buildCode);
+            return this as T;
+        }
     }
 }

--- a/src/CodeGenHelpers/CodeGenHelpers.projitems
+++ b/src/CodeGenHelpers/CodeGenHelpers.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AccessibilityExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BuilderBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BuilderBase{T}.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CompilerWarnings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ClassBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CodeBuilderExtensions.cs" />

--- a/src/CodeGenHelpers/CompilerWarnings.cs
+++ b/src/CodeGenHelpers/CompilerWarnings.cs
@@ -1,0 +1,20 @@
+﻿namespace CodeGenHelpers
+{
+    public class CompilerWarnings
+    {
+        /// <summary>
+        /// The field is never used
+        /// </summary>
+        public const string CS0169 = nameof(CS0169);
+
+        /// <summary>
+        /// The member is marked obsolete
+        /// </summary>
+        public const string CS0612 = nameof(CS0612);
+
+        /// <summary>
+        /// The member is marked obsolete with a message
+        /// </summary>
+        public const string CS0618 = nameof(CS0618);
+    }
+}


### PR DESCRIPTION
# Description

There may be several times in which generated code may result in a compiler warning or error. This will allow you to surround a Class, Method, Property, etc with a Pragma warning block to disable the warning/error. 

The warnings/errors could occur because of Analyzers that you've written to keep people from duplicating code that you're generating or because you're generating code that you'll then use IL weaving to further manipulate.