### PR TITLE
expose Parameters

### DIFF
--- a/src/CodeGenHelpers/ConstructorBuilder.cs
+++ b/src/CodeGenHelpers/ConstructorBuilder.cs
@@ -25,6 +25,8 @@ namespace CodeGenHelpers
 
         ConstructorBuilder IParameterized<ConstructorBuilder>.Parent => this;
 
+        public IReadOnlyCollection<ParameterBuilder<ConstructorBuilder>> Parameters => _parameters;
+
         public Accessibility? AccessModifier { get; }
 
         public ClassBuilder Class { get; }

--- a/src/CodeGenHelpers/MethodBuilder.cs
+++ b/src/CodeGenHelpers/MethodBuilder.cs
@@ -26,6 +26,8 @@ namespace CodeGenHelpers
         List<ParameterBuilder<MethodBuilder>> IParameterized<MethodBuilder>.Parameters => _parameters;
         MethodBuilder IParameterized<MethodBuilder>.Parent => this;
 
+        public IReadOnlyCollection<ParameterBuilder<MethodBuilder>> Parameters => _parameters;
+
         public string Name { get; }
 
         public string ReturnType { get; private set; }


### PR DESCRIPTION
# Description

Exposes the Method Parameters so that additional logical steps can be taken while working with the MethodBuilder or ConstructorBuilder.

closes #14