### PR TITLE
Pack code as content

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,8 @@ stages:
         publishLocation: 'pipeline'
 
     - task: NuGetCommand@2
+      displayName: NuGet Push
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       inputs:
         command: 'push'
         packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'

--- a/src/CodeGenHelpers/AvantiPoint.CodeGenHelpers.csproj
+++ b/src/CodeGenHelpers/AvantiPoint.CodeGenHelpers.csproj
@@ -9,10 +9,22 @@
     <PackageTags>source generators;codegen;avantipoint;roslyn</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
+
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddGeneratorsToOutput</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <ItemGroup>
     <None Update="ReadMe.txt" Pack="true" PackagePath="" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" PrivateAssets="all" />
+    <None Include="AvantiPoint.CodeGenHelpers.props" Pack="true" PackagePath="build" />
   </ItemGroup>
+
+  <Target Name="_AddGeneratorsToOutput">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="*.cs" PackagePath="build/content" />
+      <TfmSpecificPackageFile Include="Internals\*.cs" PackagePath="build/content/Internals" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/CodeGenHelpers/AvantiPoint.CodeGenHelpers.props
+++ b/src/CodeGenHelpers/AvantiPoint.CodeGenHelpers.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project>
+
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)content\**\*.cs" LinkBase="CodeGenHelpers" />
+  </ItemGroup>
+
+</Project>

--- a/src/CodeGenHelpers/Internals/CodeBuilderExtensions.cs
+++ b/src/CodeGenHelpers/Internals/CodeBuilderExtensions.cs
@@ -6,7 +6,6 @@ namespace CodeGenHelpers.Internals
 {
     internal static class CodeBuilderExtensions
     {
-
         private static readonly Dictionary<string, string> _mappings = new Dictionary<string, string>
         {
             { "Boolean", "bool" },

--- a/src/CodeGenHelpers/Internals/ISymbolExtensions.cs
+++ b/src/CodeGenHelpers/Internals/ISymbolExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !DISABLE_CODEGENHELPERS_SYMBOLEXTENSIONS
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,18 +12,18 @@ namespace CodeGenHelpers.Internals
         private static readonly Dictionary<string, string> _fullNamesMaping = new Dictionary<string, string>
             (StringComparer.OrdinalIgnoreCase)
             {
-                { "string",     typeof(string).ToString()},
-                { "long",       typeof(long).ToString()},
-                { "int",        typeof(int).ToString()},
-                { "short",      typeof(short).ToString()},
-                { "ulong",      typeof(ulong).ToString()},
-                { "uint",       typeof(uint).ToString()},
-                { "ushort",     typeof(ushort).ToString()},
-                { "byte",       typeof(byte).ToString()},
-                { "double",     typeof(double).ToString()},
-                { "float",      typeof(float).ToString()},
-                { "decimal",    typeof(decimal).ToString()},
-                { "bool",       typeof(bool).ToString()},
+                { "string",     typeof(string).ToString()  },
+                { "long",       typeof(long).ToString()    },
+                { "int",        typeof(int).ToString()     },
+                { "short",      typeof(short).ToString()   },
+                { "ulong",      typeof(ulong).ToString()   },
+                { "uint",       typeof(uint).ToString()    },
+                { "ushort",     typeof(ushort).ToString()  },
+                { "byte",       typeof(byte).ToString()    },
+                { "double",     typeof(double).ToString()  },
+                { "float",      typeof(float).ToString()   },
+                { "decimal",    typeof(decimal).ToString() },
+                { "bool",       typeof(bool).ToString()    },
             };
 
         public static string GetFullMetadataName(this INamespaceOrTypeSymbol symbol)
@@ -116,3 +117,4 @@ namespace CodeGenHelpers.Internals
         }
     }
 }
+#endif

--- a/src/CodeGenHelpers/ReadMe.txt
+++ b/src/CodeGenHelpers/ReadMe.txt
@@ -1,14 +1,3 @@
 ﻿Thanks for downloading the AvantiPoint CodeGenHelpers. This helper library will help you more easily write Source Generators with a pattern that allows you to pass in strings, some System Type's or Roslyn Type Symbols. The generated code can be added to the builder in any order and will output a nicely formatted source file.
 
-To include this in your source generator be sure that you've updated your csproj to reflect something like the following:
-
-<ItemGroup>
-  <PackageReference Include="AvantiPoint.CodeGenHelpers"
-                    Version="{Your installed version}"
-                    PrivateAssets="all"
-                    GeneratePathProperty="true" />
-  <None Include="$(PkgAvantiPoint_CodeGenHelpers)\lib\netstandard2.0\*.dll"
-        Pack="true"
-        PackagePath="analyzers/dotnet/cs"
-        Visible="false" />
-</ItemGroup>
+To make this easier to deal with, the CodeGenHelpers have been added as linked source code to eliminate issues with assembly references.

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.2",
+  "version": "1.3",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
# Description

Due to issues with Roslyn Generators not being able to properly reference the CodeGenHelpers while referenced from a local project, rather than packing the generated dll, this will now instead generate a package with the code being linked in via build props. 