### PR TITLE
Changed `ref` to `in` keyword

### DIFF
--- a/src/CodeGenHelpers/BuilderBase.cs
+++ b/src/CodeGenHelpers/BuilderBase.cs
@@ -7,9 +7,9 @@ namespace CodeGenHelpers
     {
         protected readonly List<string> _pragmaWarnings = new List<string>();
 
-        internal abstract void Write(ref CodeWriter writer);
+        internal abstract void Write(in CodeWriter writer);
 
-        void IBuilder.Write(ref CodeWriter writer)
+        void IBuilder.Write(in CodeWriter writer)
         {
             var warnings = string.Join(", ", _pragmaWarnings.Distinct());
             if(_pragmaWarnings.Any())
@@ -17,7 +17,7 @@ namespace CodeGenHelpers
                 writer.AppendUnindentedLine($"#pragma warning disable {warnings}");
             }
 
-            Write(ref writer);
+            Write(writer);
 
             if (_pragmaWarnings.Any())
             {

--- a/src/CodeGenHelpers/ClassBuilder.cs
+++ b/src/CodeGenHelpers/ClassBuilder.cs
@@ -262,11 +262,11 @@ namespace CodeGenHelpers
 
         public string BuildSafe() => Builder.BuildSafe();
 
-        internal override void Write(ref CodeWriter writer)
+        internal override void Write(in CodeWriter writer)
         {
-            _xmlDoc.Write(ref writer);
+            _xmlDoc.Write(writer);
 
-            WriteClassAttributes(_classAttributes, ref writer);
+            WriteClassAttributes(_classAttributes, writer);
 
             var staticDeclaration = IsStatic ? "static " : string.Empty;
 
@@ -301,19 +301,19 @@ namespace CodeGenHelpers
             using (writer.Block(string.Join(" ", classDeclaration.Where(x => !string.IsNullOrEmpty(x))), _constraints.ToArray()))
             {
                 var hadOutput = false;
-                hadOutput = InvokeBuilderWrite(_events, ref hadOutput, ref writer);
-                hadOutput = InvokeBuilderWrite(_properties.Where(x => x.FieldTypeValue == PropertyBuilder.FieldType.Const && x.IsStatic == false), ref hadOutput, ref writer, true);
-                hadOutput = InvokeBuilderWrite(_properties.Where(x => x.FieldTypeValue == PropertyBuilder.FieldType.Const && x.IsStatic == true), ref hadOutput, ref writer, true);
-                hadOutput = InvokeBuilderWrite(_properties.Where(x => x.FieldTypeValue == PropertyBuilder.FieldType.ReadOnly), ref hadOutput, ref writer, true);
-                hadOutput = InvokeBuilderWrite(_properties.Where(x => x.FieldTypeValue == PropertyBuilder.FieldType.Default), ref hadOutput, ref writer, true);
-                hadOutput = InvokeBuilderWrite(_constructors, ref hadOutput, ref writer);
-                hadOutput = InvokeBuilderWrite(_properties.Where(x => x.FieldTypeValue == PropertyBuilder.FieldType.Property), ref hadOutput, ref writer);
-                hadOutput = InvokeBuilderWrite(_methods, ref hadOutput, ref writer);
-                InvokeBuilderWrite(_nestedClass, ref hadOutput, ref writer);
+                hadOutput = InvokeBuilderWrite(_events, ref hadOutput, writer);
+                hadOutput = InvokeBuilderWrite(_properties.Where(x => x.FieldTypeValue == PropertyBuilder.FieldType.Const && x.IsStatic == false), ref hadOutput, writer, true);
+                hadOutput = InvokeBuilderWrite(_properties.Where(x => x.FieldTypeValue == PropertyBuilder.FieldType.Const && x.IsStatic == true), ref hadOutput, writer, true);
+                hadOutput = InvokeBuilderWrite(_properties.Where(x => x.FieldTypeValue == PropertyBuilder.FieldType.ReadOnly), ref hadOutput, writer, true);
+                hadOutput = InvokeBuilderWrite(_properties.Where(x => x.FieldTypeValue == PropertyBuilder.FieldType.Default), ref hadOutput, writer, true);
+                hadOutput = InvokeBuilderWrite(_constructors, ref hadOutput, writer);
+                hadOutput = InvokeBuilderWrite(_properties.Where(x => x.FieldTypeValue == PropertyBuilder.FieldType.Property), ref hadOutput, writer);
+                hadOutput = InvokeBuilderWrite(_methods, ref hadOutput, writer);
+                InvokeBuilderWrite(_nestedClass, ref hadOutput, writer);
             }
         }
 
-        private static void WriteClassAttributes(IEnumerable<string> classAttributes, ref CodeWriter writer)
+        private static void WriteClassAttributes(IEnumerable<string> classAttributes, in CodeWriter writer)
         {
             foreach (var attr in classAttributes.Distinct().OrderBy(x => x))
             {
@@ -321,7 +321,7 @@ namespace CodeGenHelpers
             }
         }
 
-        private static bool InvokeBuilderWrite<T>(IEnumerable<T> builders, ref bool hadOutput, ref CodeWriter writer, bool group = false)
+        private static bool InvokeBuilderWrite<T>(IEnumerable<T> builders, ref bool hadOutput, in CodeWriter writer, bool group = false)
             where T : IBuilder
         {
             if (builders is null || !builders.Any())
@@ -337,7 +337,7 @@ namespace CodeGenHelpers
             while (queue.Any())
             {
                 var builder = queue.Dequeue();
-                builder.Write(ref writer);
+                builder.Write(writer);
 
                 if (!group && queue.Any())
                     writer.NewLine();

--- a/src/CodeGenHelpers/CodeBuilder.cs
+++ b/src/CodeGenHelpers/CodeBuilder.cs
@@ -124,7 +124,7 @@ namespace CodeGenHelpers
                 while (clone.Any())
                 {
                     var output = clone.Dequeue();
-                    output.Write(ref writer);
+                    output.Write(writer);
 
                     if (clone.Any())
                         writer.NewLine();

--- a/src/CodeGenHelpers/ConstructorBuilder.cs
+++ b/src/CodeGenHelpers/ConstructorBuilder.cs
@@ -176,10 +176,10 @@ namespace CodeGenHelpers
             return Class.AddConstructor(accessModifier);
         }
 
-        internal override void Write(ref CodeWriter writer)
+        internal override void Write(in CodeWriter writer)
         {
             _xmlDoc.RemoveUnusedParameters(_parameters);
-            _xmlDoc.Write(ref writer);
+            _xmlDoc.Write(writer);
 
             foreach (var attribute in _attributes)
                 writer.AppendLine($"[{attribute}]");

--- a/src/CodeGenHelpers/DocumentationComment.cs
+++ b/src/CodeGenHelpers/DocumentationComment.cs
@@ -21,7 +21,7 @@ namespace CodeGenHelpers
 
         internal string InheritFrom { get; set; }
 
-        internal void Write(ref CodeWriter writer)
+        internal void Write(in CodeWriter writer)
         {
             if (InheritDoc)
             {

--- a/src/CodeGenHelpers/EnumBuilder.cs
+++ b/src/CodeGenHelpers/EnumBuilder.cs
@@ -88,9 +88,9 @@ namespace CodeGenHelpers
             return this;
         }
 
-        void IBuilder.Write(ref CodeWriter writer)
+        void IBuilder.Write(in CodeWriter writer)
         {
-            _xmlDoc.Write(ref writer);
+            _xmlDoc.Write(writer);
 
             var queue = new Queue<IBuilder>();
             _values.OrderBy(x => x.Value)
@@ -115,7 +115,7 @@ namespace CodeGenHelpers
                 while (queue.Any())
                 {
                     var value = queue.Dequeue();
-                    value.Write(ref writer);
+                    value.Write(writer);
 
                     if (queue.Any())
                     {

--- a/src/CodeGenHelpers/EnumValueBuilder.cs
+++ b/src/CodeGenHelpers/EnumValueBuilder.cs
@@ -56,9 +56,9 @@ namespace CodeGenHelpers
             return this;
         }
 
-        void IBuilder.Write(ref CodeWriter writer)
+        void IBuilder.Write(in CodeWriter writer)
         {
-            _xmlDoc.Write(ref writer);
+            _xmlDoc.Write(writer);
 
             foreach (var attr in _attributes.OrderBy(x => x))
             {

--- a/src/CodeGenHelpers/EventBuilder.cs
+++ b/src/CodeGenHelpers/EventBuilder.cs
@@ -165,7 +165,7 @@ namespace CodeGenHelpers
             return this;
         }
 
-        internal override void Write(ref CodeWriter writer)
+        internal override void Write(in CodeWriter writer)
         {
             var @static = _static ? "static " : string.Empty;
             var eventDeclaration = $"{_declaredAccessibility.Code()} {@static}event {_eventDelegateType} {Name}";

--- a/src/CodeGenHelpers/IBuilder.cs
+++ b/src/CodeGenHelpers/IBuilder.cs
@@ -2,6 +2,6 @@
 {
     internal interface IBuilder
     {
-        void Write(ref CodeWriter writer);
+        void Write(in CodeWriter writer);
     }
 }

--- a/src/CodeGenHelpers/MethodBuilder.cs
+++ b/src/CodeGenHelpers/MethodBuilder.cs
@@ -173,7 +173,7 @@ namespace CodeGenHelpers
             return this;
         }
 
-        internal override void Write(ref CodeWriter writer)
+        internal override void Write(in CodeWriter writer)
         {
             var output = string.IsNullOrEmpty(ReturnType) ? "void" : ReturnType.Trim();
             if (IsAsync)
@@ -190,7 +190,7 @@ namespace CodeGenHelpers
             output = $"{AccessModifier.Code()} {output} {Name}({parameters})";
 
             _xmlDoc.RemoveUnusedParameters(_parameters);
-            _xmlDoc.Write(ref writer);
+            _xmlDoc.Write(writer);
 
             foreach (var attribute in _attributes)
                 writer.AppendLine($"[{attribute}]");

--- a/src/CodeGenHelpers/PropertyBuilder.cs
+++ b/src/CodeGenHelpers/PropertyBuilder.cs
@@ -232,9 +232,9 @@ namespace CodeGenHelpers
             return this;
         }
 
-        void IBuilder.Write(ref CodeWriter writer)
+        void IBuilder.Write(in CodeWriter writer)
         {
-            _xmlDoc.Write(ref writer);
+            _xmlDoc.Write(writer);
 
             foreach (var attribute in _attributes)
                 writer.AppendLine($"[{attribute}]");

--- a/src/CodeGenHelpers/SwitchBuilder.cs
+++ b/src/CodeGenHelpers/SwitchBuilder.cs
@@ -39,7 +39,7 @@ namespace CodeGenHelpers
             {
                 foreach (IBuilder @case in _switchCases)
                 {
-                    @case.Write(ref writer);
+                    @case.Write(writer);
                 }
             }
         }

--- a/src/CodeGenHelpers/SwitchCaseBuilder.cs
+++ b/src/CodeGenHelpers/SwitchCaseBuilder.cs
@@ -26,7 +26,7 @@ namespace CodeGenHelpers
             return _parent;
         }
 
-        void IBuilder.Write(ref CodeWriter writer)
+        void IBuilder.Write(in CodeWriter writer)
         {
             if (_parent.Expression)
             {


### PR DESCRIPTION
This is a small refactor that will make sure that anyone can change the `CodeWriter` reference.

-Fixes #23 