### PR TITLE
Bugfix empty body on abstract method

### DIFF
--- a/src/CodeGenHelpers/MethodBuilder.cs
+++ b/src/CodeGenHelpers/MethodBuilder.cs
@@ -216,6 +216,13 @@ namespace CodeGenHelpers
 
             foreach (var attribute in _attributes)
                 writer.AppendLine($"[{attribute}]");
+
+            if (IsAbstract)
+            {
+                writer.AppendLine($"{output};");
+                return;
+            }
+
             using (writer.Block(output.Trim(), _generics.Contraints()))
             {
                 _methodBodyWriter?.Invoke(writer);

--- a/tests/CodeGenHelpers.Tests/SampleCode/SampleAbstractMethod.cs
+++ b/tests/CodeGenHelpers.Tests/SampleCode/SampleAbstractMethod.cs
@@ -11,8 +11,6 @@ namespace CodeGenHelpers.SampleCode
 {
     partial class SampleAbstractMethod
     {
-        abstract void MyAbstractMethod()
-        {
-        }
+         abstract void MyAbstractMethod();
     }
 }


### PR DESCRIPTION
Fixed a bug with abstract methods body.
An abstract method can't have a body.

The new output is:
```csharp
namespace CodeGenHelpers.SampleCode
{
    partial class SampleAbstractMethod
    {
         abstract void MyAbstractMethod();
    }
}
```