### PR TITLE
Add overload to ClassBuilder.AddNestedClass that allows setting partial

### DIFF
--- a/src/CodeGenHelpers/ClassBuilder.cs
+++ b/src/CodeGenHelpers/ClassBuilder.cs
@@ -270,9 +270,12 @@ namespace CodeGenHelpers
             return this;
         }
 
-        public ClassBuilder AddNestedClass(string name, Accessibility? accessModifier = null)
+        public ClassBuilder AddNestedClass(string name, Accessibility? accessModifier = null) =>
+            AddNestedClass(name, false, accessModifier);
+
+        public ClassBuilder AddNestedClass(string name, bool partial, Accessibility? accessModifier = null)
         {
-            var builder = new ClassBuilder(name, Builder, false);
+            var builder = new ClassBuilder(name, Builder, partial);
             if (accessModifier.HasValue)
                 builder.WithAccessModifier(accessModifier.Value);
 


### PR DESCRIPTION
Currently AddNestedClass always sets `partial` to false when creating a new ClassBuilder object in AddNestedClass. This is a problem when one is trying to generate new code for a nested class, like the `Bar` class in the following example, as we must mark any new implementations of the class as partial:
```csharp
namespace Kinen.Test
{
    namespace Nested
    {
        namespace NestedAgain
        {
            public partial class Foo
            {
                [Memento]
                private partial class Bar 
                {
                    [...]
                }
            }
        }
    }
}
```

This leads to invalid generated code like the following:
```csharp
namespace Kinen.Test.Nested.NestedAgain
{
    public partial class Foo
    {
        private class Bar : IOriginator
        {
            [...]
        }
    }
}
```
Adding a new overload to the AddNestedClass method that allows to set the attribute will fix this problem, which is what this PR proposes.

PS: Thanks for the great library 😉 