### PR TITLE
Nullable check

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.109" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.113" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/CodeGenHelpers/AvantiPoint.CodeGenHelpers.csproj
+++ b/src/CodeGenHelpers/AvantiPoint.CodeGenHelpers.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="CodeGenHelpers.Tests" />
     <None Update="ReadMe.txt" Pack="true" PackagePath="" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="all" />
     <None Include="AvantiPoint.CodeGenHelpers.props" Pack="true" PackagePath="build" />
   </ItemGroup>
 

--- a/src/CodeGenHelpers/Internals/ISymbolExtensions.cs
+++ b/src/CodeGenHelpers/Internals/ISymbolExtensions.cs
@@ -113,6 +113,9 @@ namespace CodeGenHelpers.Internals
 
         public static bool IsNullable(this ITypeSymbol type)
         {
+            if (type.NullableAnnotation == NullableAnnotation.Annotated)
+                return true;
+            
             return ((type as INamedTypeSymbol)?.IsGenericType ?? false)
                 && type.OriginalDefinition.ToDisplayString().Equals("System.Nullable<T>", StringComparison.OrdinalIgnoreCase);
         }
@@ -121,7 +124,7 @@ namespace CodeGenHelpers.Internals
         {
             if (type.IsNullable())
             {
-                nullableType = ((INamedTypeSymbol)type).TypeArguments.First();
+                nullableType = type.NullableAnnotation == NullableAnnotation.Annotated ? type : ((INamedTypeSymbol)type).TypeArguments.First();
                 return true;
             }
             else

--- a/tests/CodeGenHelpers.Tests/CodeGenHelpers.Tests.csproj
+++ b/tests/CodeGenHelpers.Tests/CodeGenHelpers.Tests.csproj
@@ -12,13 +12,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
# Description

Fixes bug with IsNullable extension. This will now ensure that the NullableAnnotation is checked so that when compiling in a nullable context we get the right check for whether or not a property is nullable.

Updates package dependencies