### PR TITLE
Expose public extensions

### DIFF
--- a/src/CodeGenHelpers/Extensions/GeneratorExtensions.cs
+++ b/src/CodeGenHelpers/Extensions/GeneratorExtensions.cs
@@ -1,0 +1,17 @@
+﻿using CodeGenHelpers;
+using Microsoft.CodeAnalysis;
+
+namespace AvantiPoint.CodeGenHelpers.Extensions;
+
+public static class GeneratorExtensions
+{
+    public static void AddSource(this GeneratorExecutionContext context, ClassBuilder builder)
+    {
+        context.AddSource($"{builder.FullyQualifiedName}.g.cs", builder.Build());
+    }
+
+    public static void AddSource(this SourceProductionContext context, ClassBuilder builder)
+    {
+        context.AddSource($"{builder.FullyQualifiedName}.g.cs", builder.Build());
+    }
+}

--- a/src/CodeGenHelpers/Extensions/SymbolExtensions.cs
+++ b/src/CodeGenHelpers/Extensions/SymbolExtensions.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Linq;
+using CodeGenHelpers.Internals;
+using Microsoft.CodeAnalysis;
+
+namespace AvantiPoint.CodeGenHelpers.Extensions;
+
+public static class SymbolExtensions
+{
+    public static string GetQualifiedTypeName(ITypeSymbol typeSymbol)
+    {
+        var type = typeSymbol.GetTypeName();
+        if (!type.Contains(".") || typeSymbol is not INamedTypeSymbol namedTypeSymbol)
+        {
+            return type;
+        }
+
+        var @namespace = namedTypeSymbol.ContainingNamespace.ToString();
+        var typeName = namedTypeSymbol.Name;
+
+        if (typeSymbol.ContainingType is not null)
+        {
+            return $"{GetQualifiedTypeName(typeSymbol.ContainingType)}.{typeSymbol.Name}";
+        }
+
+        var fullyQualifiedName = $"{@namespace}.{typeName}";
+
+        if (namedTypeSymbol.IsGenericType)
+        {
+            var generics = namedTypeSymbol.TypeArguments.Select(x => GetQualifiedTypeName(x));
+            var baseName = fullyQualifiedName;
+            var nullable = string.Empty;
+            if (baseName.EndsWith("?", StringComparison.InvariantCulture))
+            {
+                baseName = baseName.Substring(0, baseName.Length - 1);
+                nullable = "?";
+            }
+
+            fullyQualifiedName = $"{baseName}<{string.Join(", ", generics)}>{nullable}";
+        }
+
+        if (fullyQualifiedName.Contains(".") && !fullyQualifiedName.StartsWith("global::", StringComparison.InvariantCulture))
+        {
+            fullyQualifiedName = $"global::{fullyQualifiedName}";
+        }
+
+        return fullyQualifiedName;
+    }
+
+    public static bool IsNullable(this ITypeSymbol type)
+    {
+        if (type.NullableAnnotation == NullableAnnotation.Annotated)
+            return true;
+
+        return ((type as INamedTypeSymbol)?.IsGenericType ?? false)
+            && type.OriginalDefinition.ToDisplayString().Equals("System.Nullable<T>", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static bool IsNullable(this ITypeSymbol type, out ITypeSymbol? nullableType)
+    {
+        if (type.IsNullable())
+        {
+            nullableType = type.NullableAnnotation == NullableAnnotation.Annotated ? type : ((INamedTypeSymbol)type).TypeArguments.First();
+            return true;
+        }
+        else
+        {
+            nullableType = null;
+            return false;
+        }
+    }
+}

--- a/src/CodeGenHelpers/Internals/ISymbolExtensions.cs
+++ b/src/CodeGenHelpers/Internals/ISymbolExtensions.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using AvantiPoint.CodeGenHelpers.Extensions;
 using Microsoft.CodeAnalysis;
 
 #pragma warning disable IDE0008
@@ -109,29 +110,6 @@ namespace CodeGenHelpers.Internals
             }
 
             return output;
-        }
-
-        public static bool IsNullable(this ITypeSymbol type)
-        {
-            if (type.NullableAnnotation == NullableAnnotation.Annotated)
-                return true;
-            
-            return ((type as INamedTypeSymbol)?.IsGenericType ?? false)
-                && type.OriginalDefinition.ToDisplayString().Equals("System.Nullable<T>", StringComparison.OrdinalIgnoreCase);
-        }
-
-        public static bool IsNullable(this ITypeSymbol type, out ITypeSymbol? nullableType)
-        {
-            if (type.IsNullable())
-            {
-                nullableType = type.NullableAnnotation == NullableAnnotation.Annotated ? type : ((INamedTypeSymbol)type).TypeArguments.First();
-                return true;
-            }
-            else
-            {
-                nullableType = null;
-                return false;
-            }
         }
     }
 }


### PR DESCRIPTION
# Description

Exposing public extensions for IsNullable & GetQualifiedTypeName
Adding public extensions for GeneratorExecutionContext & SourceProductionContext to add a ClassBuilder directly as Source

**NOTE**: GetQualifiedTypeName will return `global::FullyQualifiedNamespace.TypeName`