### PR TITLE
Add support for static get-only properties

### DIFF
--- a/src/CodeGenHelpers/PropertyBuilder.cs
+++ b/src/CodeGenHelpers/PropertyBuilder.cs
@@ -118,7 +118,7 @@ namespace CodeGenHelpers
             AccessModifier = accessModifier;
             return this;
         }
-        
+
         public PropertyBuilder Override(bool @override = true)
         {
             _override = @override;
@@ -128,7 +128,11 @@ namespace CodeGenHelpers
         public PropertyBuilder MakeStatic()
         {
             IsStatic = true;
-            FieldTypeValue = FieldType.Const;
+            if (string.IsNullOrEmpty(_getterExpression))
+            {
+                FieldTypeValue = FieldType.Const;
+            }
+
             return this;
         }
 
@@ -167,6 +171,7 @@ namespace CodeGenHelpers
         public PropertyBuilder WithGetterExpression(string expression)
         {
             _getterExpression = expression;
+            FieldTypeValue = FieldType.Property;
             return this;
         }
 
@@ -260,7 +265,7 @@ namespace CodeGenHelpers
             {
                 FieldType.Const => $"{AccessModifier.Code()}{isNew} const {type} {name}",
                 FieldType.ReadOnly => $"{AccessModifier.Code()}{isNew}{_static} readonly {type} {name}",
-                _ => additionalModifier is null 
+                _ => additionalModifier is null
                     ? $"{AccessModifier.Code()}{isNew}{_static} {type} {name}"
                     : $"{AccessModifier.Code()} {additionalModifier} {type} {name}"
             }).Trim();

--- a/tests/CodeGenHelpers.Tests/Tests/PropertyTests.cs
+++ b/tests/CodeGenHelpers.Tests/Tests/PropertyTests.cs
@@ -174,6 +174,52 @@ namespace CodeGenHelpers.Tests
             AreEqual(expected, builder);
         }
 
+        [Fact]
+        public void AddsGetterExpressionToStaticProperty()
+        {
+            var builder = CodeBuilder.Create("AwesomeApp")
+                .AddClass("SampleClass")
+                .AddProperty("Test")
+                .MakePublicProperty()
+                .MakeStatic()
+                .SetType("string")
+                .WithGetterExpression("\"test\"")
+                .Class;
+
+            var expected = @"namespace AwesomeApp
+{
+    partial class SampleClass
+    {
+        public static string Test => ""test"";
+    }
+}
+";
+            AreEqual(expected, builder);
+        }
+
+        [Fact]
+        public void AddsStaticToPropertyWithGetterExpression()
+        {
+            var builder = CodeBuilder.Create("AwesomeApp")
+                .AddClass("SampleClass")
+                .AddProperty("Test")
+                .MakePublicProperty()
+                .WithGetterExpression("\"test\"")
+                .MakeStatic()
+                .SetType("string")
+                .Class;
+
+            var expected = @"namespace AwesomeApp
+{
+    partial class SampleClass
+    {
+        public static string Test => ""test"";
+    }
+}
+";
+            AreEqual(expected, builder);
+        }
+
         private void AreEqual(string expected, ClassBuilder builder)
         {
             var expectedOutput = $@"//------------------------------------------------------------------------------


### PR DESCRIPTION
It is currently not possible to generate `static` get-only properties, only `static readonly` fields.

### Example
```csharp
namespace AwesomeApp
{
    partial class SampleClass
    {
        public static string Test => "test";
    }
}
```

This pattern is a required for implementing [static abstract interface members](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-11.0/static-abstracts-in-interfaces).

This PR updates the `WithGetterExpression` to update the `FieldType` to `FieldType.Property` and prevents the `MakeStatic` method from changing the `FieldType` to `FieldType.Const` if a `_getterExpression` is present. Happy to take suggestions for improvements to this approach.